### PR TITLE
Usage messages for tcsh scripts

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  cleanup.sh [options] <project_path> <source_name>
+   echo "Usage:  cleanup.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -19,13 +19,13 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  cleanup.sh <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file, and
-   echo       [options] are:
-   echo                 -p      purge (keep sources only)
+   echo "Usage:  cleanup.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file, and"
+   echo "      [options] are:"
+   echo "                -p      purge (keep sources only)"
    exit 1
 endif
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, April 2013
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  cleanup.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments (no options---this is a placeholder)
 set argline=(`getopt "p" $argv[1-]`)
 set cmdargs=`echo "$argline" | awk 'BEGIN {FS = "-- "} END {print $2}'`

--- a/scripts/graywolf.sh
+++ b/scripts/graywolf.sh
@@ -9,11 +9,6 @@
 # Modified November 2013 for congestion feedback
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  graywolf.sh <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "kdf" $argv[1-]`)
 set cmdargs=`echo "$argline" | awk 'BEGIN {FS = "-- "} END {print $2}'`
@@ -35,7 +30,6 @@ else
    echo
    echo "  Options to specific tools can be specified with the following"
    echo "  variables in project_vars.sh:"
-   echo
    echo
    exit 1
 endif

--- a/scripts/graywolf.sh
+++ b/scripts/graywolf.sh
@@ -10,7 +10,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  graywolf.sh <project_path> <source_name>
+   echo "Usage:  graywolf.sh <project_path> <source_name>"
    exit 1
 endif
 
@@ -23,18 +23,18 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  graywolf.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file, and
-   echo       [options] are:
-   echo			-k	keep working files
-   echo			-d	generate DEF file for routing
-   echo			-f	final placement.  Don't run if routing succeeded
+   echo "Usage:  graywolf.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file, and"
+   echo "      [options] are:"
+   echo "                -k      keep working files"
+   echo "                -d      generate DEF file for routing"
+   echo "                -f      final placement.  Don't run if routing succeeded"
    echo
-   echo	  Options to specific tools can be specified with the following
-   echo	  variables in project_vars.sh:
+   echo "  Options to specific tools can be specified with the following"
+   echo "  variables in project_vars.sh:"
    echo
    echo
    exit 1

--- a/scripts/magic_db.sh
+++ b/scripts/magic_db.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 8/20/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  magic_db.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "x" $argv[1-]`)
 set options=`echo "$argline" | awk 'BEGIN {FS = "-- "} END {print $1}'`
@@ -27,7 +22,6 @@ else
    echo "      <source_name> is the root name of the verilog file, and"
    echo "      [options] are:"
    echo "                -x      extract only (use existing layout)"
-   echo
    exit 1
 endif
 

--- a/scripts/magic_db.sh
+++ b/scripts/magic_db.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  magic_db.sh [options] <project_path> <source_name>
+   echo "Usage:  magic_db.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -20,13 +20,13 @@ if ($argc >= 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  magic_db.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file, and
-   echo       [options] are:
-   echo                 -x      extract only (use existing layout)
+   echo "Usage:  magic_db.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file, and"
+   echo "      [options] are:"
+   echo "                -x      extract only (use existing layout)"
    echo
    exit 1
 endif

--- a/scripts/magic_drc.sh
+++ b/scripts/magic_drc.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 8/20/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  magic_drc.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "" $argv[1-]`)
 

--- a/scripts/magic_drc.sh
+++ b/scripts/magic_drc.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  magic_drc.sh [options] <project_path> <source_name>
+   echo "Usage:  magic_drc.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -21,11 +21,11 @@ if ($argc >= 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  magic_drc.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
+   echo "Usage:  magic_drc.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
    exit 1
 endif
 

--- a/scripts/magic_gds.sh
+++ b/scripts/magic_gds.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  magic_gds.sh [options] <project_path> <source_name>
+   echo "Usage:  magic_gds.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -21,11 +21,11 @@ if ($argc >= 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  magic_gds.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
+   echo "Usage:  magic_gds.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
    exit 1
 endif
 

--- a/scripts/magic_gds.sh
+++ b/scripts/magic_gds.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 4/23/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  magic_gds.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "" $argv[1-]`)
 

--- a/scripts/magic_view.sh
+++ b/scripts/magic_view.sh
@@ -6,12 +6,12 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  magic_view.sh [options] <project_path> <source_name>
-   echo	Options:
-   echo		-g	Use GDS view of standard cells (default auto-detect)
-   echo		-l	Use LEF view of standard cells
-   echo		-d	Use DEF view of layout (default auto-detect)
-   echo		-m	Use magic database view of layout
+   echo "Usage:  magic_view.sh [options] <project_path> <source_name>"
+   echo "Options:"
+   echo "        -g      Use GDS view of standard cells (default auto-detect)"
+   echo "        -l      Use LEF view of standard cells"
+   echo "        -d      Use DEF view of layout (default auto-detect)"
+   echo "        -m      Use magic database view of layout"
    exit 1
 endif
 
@@ -24,11 +24,11 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  magic_view.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file, and
+   echo "Usage:  magic_view.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file, and"
    exit 1
 endif
 

--- a/scripts/magic_view.sh
+++ b/scripts/magic_view.sh
@@ -5,16 +5,6 @@
 # Tim Edwards, April 2013
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  magic_view.sh [options] <project_path> <source_name>"
-   echo "Options:"
-   echo "        -g      Use GDS view of standard cells (default auto-detect)"
-   echo "        -l      Use LEF view of standard cells"
-   echo "        -d      Use DEF view of layout (default auto-detect)"
-   echo "        -m      Use magic database view of layout"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "gldm" $argv[1-]`)
 set cmdargs=`echo "$argline" | awk 'BEGIN {FS = "-- "} END {print $2}'`
@@ -29,6 +19,11 @@ else
    echo "      <project_path> is the name of the project directory containing"
    echo "                a file called qflow_vars.sh."
    echo "      <source_name> is the root name of the verilog file, and"
+   echo "      [options] are:"
+   echo "        -g      Use GDS view of standard cells (default auto-detect)"
+   echo "        -l      Use LEF view of standard cells"
+   echo "        -d      Use DEF view of layout (default auto-detect)"
+   echo "        -m      Use magic database view of layout"
    exit 1
 endif
 

--- a/scripts/netgen_lvs.sh
+++ b/scripts/netgen_lvs.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  netgen_lvs.sh [options] <project_path> <source_name>
+   echo "Usage:  netgen_lvs.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -21,11 +21,11 @@ if ($argc >= 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  netgen_lvs.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
+   echo "Usage:  netgen_lvs.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
    exit 1
 endif
 

--- a/scripts/netgen_lvs.sh
+++ b/scripts/netgen_lvs.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 8/20/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  netgen_lvs.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "" $argv[1-]`)
 

--- a/scripts/opensta.sh
+++ b/scripts/opensta.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  opensta.sh [options] <project_path> <source_name>
+   echo "Usage:  opensta.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -21,14 +21,14 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  opensta.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
-   echo	      [options] are:
-   echo			-d	use delay file to back-annotate wire delays
-   echo			-a	append to log file (do not overwrite)
+   echo "Usage:  opensta.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
+   echo "      [options] are:"
+   echo "                -d      use delay file to back-annotate wire delays"
+   echo "                -a      append to log file (do not overwrite)"
    echo
    exit 1
 endif

--- a/scripts/opensta.sh
+++ b/scripts/opensta.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 10/05/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  opensta.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "ad" $argv[1-]`)
 
@@ -29,7 +24,6 @@ else
    echo "      [options] are:"
    echo "                -d      use delay file to back-annotate wire delays"
    echo "                -a      append to log file (do not overwrite)"
-   echo
    exit 1
 endif
 

--- a/scripts/opentimer.sh
+++ b/scripts/opentimer.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 10/02/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  opentimer.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "ad" $argv[1-]`)
 
@@ -29,7 +24,6 @@ else
    echo "      [options] are:"
    echo "                -d      use delay file to back-annotate wire delays"
    echo "                -a      append to log file (do not overwrite)"
-   echo
    exit 1
 endif
 

--- a/scripts/opentimer.sh
+++ b/scripts/opentimer.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  opentimer.sh [options] <project_path> <source_name>
+   echo "Usage:  opentimer.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -21,14 +21,14 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  opentimer.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
-   echo	      [options] are:
-   echo			-d	use delay file to back-annotate wire delays
-   echo			-a	append to log file (do not overwrite)
+   echo "Usage:  opentimer.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
+   echo "      [options] are:"
+   echo "                -d      use delay file to back-annotate wire delays"
+   echo "                -a      append to log file (do not overwrite)"
    echo
    exit 1
 endif

--- a/scripts/qrouter.sh
+++ b/scripts/qrouter.sh
@@ -6,11 +6,6 @@
 # Modified April 2013 for use with qflow
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  qrouter.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "nr" $argv[1-]`)
 

--- a/scripts/qrouter.sh
+++ b/scripts/qrouter.sh
@@ -7,7 +7,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  qrouter.sh [options] <project_path> <source_name>
+   echo "Usage:  qrouter.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -29,11 +29,11 @@ if ($argc >= 2) then
       endif
    endif
 else
-   echo Usage:  qrouter.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
+   echo "Usage:  qrouter.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
    exit 1
 endif
 

--- a/scripts/replace.sh
+++ b/scripts/replace.sh
@@ -7,7 +7,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  replace.sh <project_path> <source_name>
+   echo "Usage:  replace.sh <project_path> <source_name>"
    exit 1
 endif
 
@@ -20,18 +20,18 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  replace.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file, and
-   echo       [options] are:
-   echo			-k	keep working files
-   echo			-d	generate DEF file for routing
-   echo			-f	final placement.  Don't run if routing succeeded
+   echo "Usage:  replace.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file, and"
+   echo "      [options] are:"
+   echo "                -k      keep working files"
+   echo "                -d      generate DEF file for routing"
+   echo "                -f      final placement.  Don't run if routing succeeded"
    echo
-   echo	  Options to specific tools can be specified with the following
-   echo	  variables in project_vars.sh:
+   echo "  Options to specific tools can be specified with the following"
+   echo "  variables in project_vars.sh:"
    echo
    echo
    exit 1

--- a/scripts/replace.sh
+++ b/scripts/replace.sh
@@ -6,11 +6,6 @@
 # Tim Edwards, 12/26/18, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  replace.sh <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "kdf" $argv[1-]`)
 set cmdargs=`echo "$argline" | awk 'BEGIN {FS = "-- "} END {print $2}'`
@@ -32,7 +27,6 @@ else
    echo
    echo "  Options to specific tools can be specified with the following"
    echo "  variables in project_vars.sh:"
-   echo
    echo
    exit 1
 endif

--- a/scripts/vesta.sh
+++ b/scripts/vesta.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 if ($#argv < 2) then
-   echo Usage:  vesta.sh [options] <project_path> <source_name>
+   echo "Usage:  vesta.sh [options] <project_path> <source_name>"
    exit 1
 endif
 
@@ -21,14 +21,14 @@ if ($argc == 2) then
    set argv1=`echo $cmdargs | cut -d' ' -f1`
    set argv2=`echo $cmdargs | cut -d' ' -f2`
 else
-   echo Usage:  vesta.sh [options] <project_path> <source_name>
-   echo   where
-   echo       <project_path> is the name of the project directory containing
-   echo                 a file called qflow_vars.sh.
-   echo       <source_name> is the root name of the verilog file
-   echo	      [options] are:
-   echo			-d	use delay file to back-annotate wire delays
-   echo			-a	append to log file (do not overwrite)
+   echo "Usage:  vesta.sh [options] <project_path> <source_name>"
+   echo "  where"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo "      <source_name> is the root name of the verilog file"
+   echo "      [options] are:"
+   echo "                -d      use delay file to back-annotate wire delays"
+   echo "                -a      append to log file (do not overwrite)"
    echo
    exit 1
 endif

--- a/scripts/vesta.sh
+++ b/scripts/vesta.sh
@@ -5,11 +5,6 @@
 # Tim Edwards, 10/29/13, for Open Circuit Design
 #----------------------------------------------------------
 
-if ($#argv < 2) then
-   echo "Usage:  vesta.sh [options] <project_path> <source_name>"
-   exit 1
-endif
-
 # Split out options from the main arguments
 set argline=(`getopt "ad" $argv[1-]`)
 
@@ -29,7 +24,6 @@ else
    echo "      [options] are:"
    echo "                -d      use delay file to back-annotate wire delays"
    echo "                -a      append to log file (do not overwrite)"
-   echo
    exit 1
 endif
 

--- a/scripts/yosys.sh
+++ b/scripts/yosys.sh
@@ -24,26 +24,26 @@ if ($#argv == 2 || $#argv == 3) then
       set sourcename=""
    endif
 else
-   echo Usage:  yosys.sh <project_path> <module_name> [<source_file>]
+   echo "Usage:  yosys.sh <project_path> <module_name> [<source_file>]"
+   echo"
+   echo "  where"
+   echo"
+   echo "      <project_path> is the name of the project directory containing"
+   echo "                a file called qflow_vars.sh."
+   echo"
+   echo "      <module_name> is the name of the verilog top-level module, and"
+   echo"
+   echo "      <source_file> is the name of the verilog file, if the module"
+   echo "                name and file root name are not the same."
+   echo"
+   echo "      Options are set from project_vars.sh.  Use the following"
+   echo "      variable names:"
    echo
-   echo   where
-   echo
-   echo	      <project_path> is the name of the project directory containing
-   echo			a file called qflow_vars.sh.
-   echo
-   echo	      <module_name> is the name of the verilog top-level module, and
-   echo
-   echo	      <source_file> is the name of the verilog file, if the module
-   echo			name and file root name are not the same.
-   echo
-   echo	      Options are set from project_vars.sh.  Use the following
-   echo	      variable names:
-   echo
-   echo			$yosys_options	for yosys
-   echo			$yosys_script	for yosys
-   echo			$nobuffers	to ignore output buffering
-   echo			$inbuffers	to force input buffering
-   echo			$fanout_options	for vlogFanout
+   echo "                $yosys_options  for yosys"
+   echo "                $yosys_script   for yosys"
+   echo "                $nobuffers      to ignore output buffering"
+   echo "                $inbuffers      to force input buffering"
+   echo "                $fanout_options for vlogFanout"
    exit 1
 endif
 

--- a/scripts/yosys.sh
+++ b/scripts/yosys.sh
@@ -25,25 +25,24 @@ if ($#argv == 2 || $#argv == 3) then
    endif
 else
    echo "Usage:  yosys.sh <project_path> <module_name> [<source_file>]"
-   echo"
+   echo
    echo "  where"
-   echo"
+   echo
    echo "      <project_path> is the name of the project directory containing"
    echo "                a file called qflow_vars.sh."
-   echo"
+   echo
    echo "      <module_name> is the name of the verilog top-level module, and"
-   echo"
+   echo
    echo "      <source_file> is the name of the verilog file, if the module"
    echo "                name and file root name are not the same."
-   echo"
+   echo
    echo "      Options are set from project_vars.sh.  Use the following"
    echo "      variable names:"
-   echo
-   echo "                $yosys_options  for yosys"
-   echo "                $yosys_script   for yosys"
-   echo "                $nobuffers      to ignore output buffering"
-   echo "                $inbuffers      to force input buffering"
-   echo "                $fanout_options for vlogFanout"
+   echo "                \$yosys_options  for yosys"
+   echo "                \$yosys_script   for yosys"
+   echo "                \$nobuffers      to ignore output buffering"
+   echo "                \$inbuffers      to force input buffering"
+   echo "                \$fanout_options for vlogFanout"
    exit 1
 endif
 

--- a/scripts/yosys.sh
+++ b/scripts/yosys.sh
@@ -24,25 +24,25 @@ if ($#argv == 2 || $#argv == 3) then
       set sourcename=""
    endif
 else
-   echo "Usage:  yosys.sh <project_path> <module_name> [<source_file>]"
+   echo 'Usage:  yosys.sh <project_path> <module_name> [<source_file>]'
    echo
-   echo "  where"
+   echo '  where'
    echo
-   echo "      <project_path> is the name of the project directory containing"
-   echo "                a file called qflow_vars.sh."
+   echo '      <project_path> is the name of the project directory containing'
+   echo '                a file called qflow_vars.sh.'
    echo
-   echo "      <module_name> is the name of the verilog top-level module, and"
+   echo '      <module_name> is the name of the verilog top-level module, and'
    echo
-   echo "      <source_file> is the name of the verilog file, if the module"
-   echo "                name and file root name are not the same."
+   echo '      <source_file> is the name of the verilog file, if the module'
+   echo '                name and file root name are not the same.'
    echo
-   echo "      Options are set from project_vars.sh.  Use the following"
-   echo "      variable names:"
-   echo "                \$yosys_options  for yosys"
-   echo "                \$yosys_script   for yosys"
-   echo "                \$nobuffers      to ignore output buffering"
-   echo "                \$inbuffers      to force input buffering"
-   echo "                \$fanout_options for vlogFanout"
+   echo '      Options are set from project_vars.sh.  Use the following'
+   echo '      variable names:'
+   echo '                $yosys_options  for yosys'
+   echo '                $yosys_script   for yosys'
+   echo '                $nobuffers      to ignore output buffering'
+   echo '                $inbuffers      to force input buffering'
+   echo '                $fanout_options for vlogFanout'
    exit 1
 endif
 


### PR DESCRIPTION
Dear Tim,

I think that the 'usage' messages from tcsh scripts in qflow are somewhat inconsistent:
- quoting in `echo` commands is wrong (I often see `Missing name for redirect` because of `<>` characters and other glitches;
- the initial check on command line arguments prevents the subsequent, more verbose, help message to be printed.

This pull request tries to address most of those problems. Please let me know if the modifications are acceptable.

All the best

--
Alessandro