### PR TITLE
fix  tech load befor syslib path

### DIFF
--- a/scripts/qflow_manager.py.in
+++ b/scripts/qflow_manager.py.in
@@ -1367,16 +1367,15 @@ class QflowManager(ttk.Frame):
                             print('Diagnostic:  tech load not trusted')
 
             with open(ldir + '/qflow.magicrc', 'w') as ofile:
-                if tech_loaded == False:
-                    print('Diagnostic:  Inserting own tech load')
-                    techfile = self.get_project_techfile()
-                    if techfile:
-                        print('tech load ' + techfile + ' -noprompt', file=ofile)
-
                 for line in rclines:
                     if 'tech load' in line:
                         if tech_loaded == True:
                             print(line, file=ofile)
+                        else:
+                            techfile = self.get_project_techfile()
+                            print('Diagnostic:  Inserting own tech load')
+                            if techfile:
+                                print('tech load ' + techfile + ' -noprompt', file=ofile)
                     else:
                         print(line, file=ofile)
 

--- a/tech/osu018/osu018.sh
+++ b/tech/osu018/osu018.sh
@@ -66,7 +66,7 @@ set tielo=""		;# Cell to connect to ground, if one exists
 set tielopin_out=""	;# Output pin name of tielo cell, if it exists
 
 set separator=""		;# Separator between gate names and drive strengths
-set techfile=SCN4M_SUBM.20	;# magic techfile
+set techfile=SCN6M_SUBM.10	;# magic techfile
 set magicrc=osu018.magicrc	;# magic startup script
 set gdsfile=osu018_stdcells.gds2	;# GDS database of standard cells
 


### PR DESCRIPTION
issue: 
1.LSV failed due to tech file loading failure in qflow. the tech load cmd has been added before sys path cmd
2, fix the wrong tech file name in osu18