### PR TITLE
Fix uninitialized read in find_clock_skews

### DIFF
--- a/src/vesta.c
+++ b/src/vesta.c
@@ -3512,7 +3512,7 @@ find_clock_skews(ddataptr pathlist, char minmax)
     btptr    backtrace, freebt, pathbt, btcommon;
     btptr    selectedsource, selecteddest;
 
-    short srcdir, destdir;		// Signal direction in/out
+    short srcdir = 0, destdir;		// Signal direction in/out
     double setupdelay, holddelay;
     unsigned char result;
     char	clk_invert, clk_sense_inv;


### PR DESCRIPTION
srcdir is only used in this function to be passed down to find_clock_source
and find_clock_transition but it's never initialized anywhere.