### PR TITLE
Handle sky130_fd_sc_hd__conb_1 for pullup/pulldown

### DIFF
--- a/scripts/spi2xspice.py.in
+++ b/scripts/spi2xspice.py.in
@@ -114,6 +114,7 @@ def write_models(cellsused, celldefs, ofile, timing):
             tabstr = ''
             nout = cellrec['nout']
             nin = cellrec['nin']
+            #print("* nout=[" + str(nout) + "] nin=[" + str(nin) + "]", file=ofile) #FIXME
             for k in range(0, nout):
                 # Handle tristate functions
                 # If triidx < nin then triidx, tripin, and tripos are all valid
@@ -552,6 +553,14 @@ def read_spice(filein, fileout, celldefs, debug, modelfile, timing):
                             print('A' + instname + ' ' + outtext + ' dzero', file=ofile)
                         else:
                             print("Cell " + cellname + " has no inputs and no constant function.")
+                    elif len(inlist) == 0 and len(outlist) != 0: #FIXME
+                    #Multiple outputs with no inputs, it is a cell that is used to tie high or tie low
+                        for idx,fcn in enumerate(cellrec['function']):
+                            if fcn == '1':
+                                print('A' + instname + str(idx) + ' ' + outlist[idx] + ' done', file=ofile)
+                            elif fcn == '0':
+                                print('A' + instname + str(idx) + ' ' + outlist[idx] + ' dzero', file=ofile)
+
                     elif len(outlist) == 1:
                         print('A' + instname + ' [' + intext + '] ' + outtext + ' d_lut_' + cellname, file=ofile)
                     elif len(outlist) != 0:

--- a/scripts/spi2xspice.py.in
+++ b/scripts/spi2xspice.py.in
@@ -114,7 +114,6 @@ def write_models(cellsused, celldefs, ofile, timing):
             tabstr = ''
             nout = cellrec['nout']
             nin = cellrec['nin']
-            #print("* nout=[" + str(nout) + "] nin=[" + str(nin) + "]", file=ofile) #FIXME
             for k in range(0, nout):
                 # Handle tristate functions
                 # If triidx < nin then triidx, tripin, and tripos are all valid


### PR DESCRIPTION
When creating the xspice file, this script currently doesn't handle the case where a cell like sky130_fd_sc_hd__conb_1 that has BOTH pullup and pulldown in one cell.  It fails to create a .model and the resulting xspice file doesn't simulate.

This update changes the way this script handles cells with zero input and multiple outputs, and converts pullups to d_pullup (done), and pulldowns to d_pulldown (dzero).