### PR TITLE
Make tristate buffer work with sky130

### DIFF
--- a/scripts/spi2xspice.py.in
+++ b/scripts/spi2xspice.py.in
@@ -122,7 +122,10 @@ def write_models(cellsused, celldefs, ofile, timing):
                     if trirec[0] == '~':
                         tripos = False
                         tripin = trirec[1:]
-                    else:
+                    elif re.search(r"_b$", trirec, re.IGNORECASE): #in sky130, tristate buffers with negative logic e>
+                        tripos = False
+                        tripin = trirec
+		    else:
                         tripos = True
                         tripin = trirec
                     for triidx in range(0, nin):
@@ -169,9 +172,9 @@ def write_models(cellsused, celldefs, ofile, timing):
                         bitstr = '0'
 
                     if triidx < nin:
-                        if binstring[triidx] == '1' and tripos == True:
-                            bitstr = 'Z'
-                        elif binstring[triidx] == '0' and tripos == False:
+                        if binstring[nin - 1 - triidx] == '1' and tripos == False: #bit index is LSB first in xspice so need to flip index
+			    bitstr = 'Z'
+                        elif binstring[nin - 1 - triidx] == '0' and tripos == True:
                             bitstr = 'Z'
 
                     tabstr += bitstr

--- a/scripts/spi2xspice.py.in
+++ b/scripts/spi2xspice.py.in
@@ -125,7 +125,7 @@ def write_models(cellsused, celldefs, ofile, timing):
                     elif re.search(r"_b$", trirec, re.IGNORECASE): #in sky130, tristate buffers with negative logic e>
                         tripos = False
                         tripin = trirec
-		    else:
+                    else:
                         tripos = True
                         tripin = trirec
                     for triidx in range(0, nin):
@@ -173,7 +173,7 @@ def write_models(cellsused, celldefs, ofile, timing):
 
                     if triidx < nin:
                         if binstring[nin - 1 - triidx] == '1' and tripos == False: #bit index is LSB first in xspice so need to flip index
-			    bitstr = 'Z'
+                            bitstr = 'Z'
                         elif binstring[nin - 1 - triidx] == '0' and tripos == True:
                             bitstr = 'Z'
 


### PR DESCRIPTION
sky130 uses 'TE_B' for tristate buffers with a negative logic enable input port.  Added special case to detect '_B' for negative logic. Currently only checks it using the leading '~' pattern.

Also, updated the indexing and logic to properly generate the 'Z' output for tristate buffers modeled using 'd_lut'.

For example, currently this tristate buffer is modeled as such:

.model d_lut_sky130_fd_sc_hd__ebufn_8 d_lut (rise_delay=1n fall_delay=1n input_load=1p
+ table_values "0Z0Z")

But it really should be modeled as such:

.model d_lut_sky130_fd_sc_hd__ebufn_8 d_lut (rise_delay=1n fall_delay=1n input_load=1p
+ table_values "01ZZ")

Instead of "0Z0Z", 'table_values" should be "01ZZ"

Ordering of the ports from spice file:
.subckt sky130_fd_sc_hd__ebufn_8 A TE_B VGND VNB VPB VPWR Z

Functional ordering of the ports (no power supplies) are "A TE_B Z"

For d_lut in xspice, "table_values" is ordered based on the input port forming a binary value, LSB first.  In this case [A TE_B] forming a 2-bit pattern.

Left-most bit of "01ZZ" (bit 0):
A=0, TE_B=0 -> Output=0

Second left-most bit of "01ZZ" (bit 1):
A=1, TE_B=0 -> Output=1

Second right-most bit of "01ZZ" (bit 2):
A=0, TE_B=1 -> Output=Z

Right-most bit of "01ZZ" (bit 3):
A=1, TE_B=1 -> Output=Z