### PR TITLE
Replace inconsistent getopt declaration with unistd header

### DIFF
--- a/src/blif2BSpice.c
+++ b/src/blif2BSpice.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <math.h>
 #include <ctype.h>
 #include <float.h>
@@ -27,10 +28,6 @@
 
 #define LengthOfLine    	16384
 #define LengthOfNodeName  	512
-
-/* getopt stuff */
-extern	int	optind, getopt();
-extern	char	*optarg;
 
 void ReadNetlistAndConvert(FILE *, FILE *, char *, FILE *,
 		char *, char *, char *, int);

--- a/src/blif2Verilog.c
+++ b/src/blif2Verilog.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <math.h>
 #include <ctype.h>
 #include <float.h>
@@ -24,10 +25,6 @@
 
 #define LengthOfLine    	16384
 #define LengthOfNodeName	512
-
-/* getopt stuff */
-extern	int	optind, getopt();
-extern	char	*optarg;
 
 #define INPUT	0
 #define OUTPUT	1


### PR DESCRIPTION
The `getopt()` declaration does not match the actual function signature, the parameters are omitted. Use unistd.h as done in other places already.

At least current GCC rightfully complains:
`error: too many arguments to function ‘getopt’; expected 0, have 3`